### PR TITLE
update Auto3DaySkipper to properly handle uncatchable mons

### DIFF
--- a/bots/Auto3DaySkipper/Auto3DaySkipper.c
+++ b/bots/Auto3DaySkipper/Auto3DaySkipper.c
@@ -192,27 +192,35 @@ void GetNextReport(USB_JoystickReport_Input_t* const ReportData) {
 				else if (m_sequence == 18)
 				{
 					// Done skipping 3 days, user should check the pokemon
-					commandIndex = 66;
-					m_endIndex = 101;
+					commandIndex = 68;
+					m_endIndex = 103;
 				}
 				else if (m_sequence == 19)
 				{
 					// see if we need to wait a bit longer for the game to start up
 					if (m_titleScreenBuffer)
 					{
-						commandIndex = 102; // do the extra wait
+						commandIndex = 104; // do the extra wait
 					}
 					else
 					{
-						commandIndex = 103; // skip the extra wait
+						commandIndex = 105; // skip the extra wait
 					}
-					m_endIndex = 104;
+					m_endIndex = 106;
 					m_sequence = 0;
 				}
 				else if (m_sequence % 5 == 3)	// 3,8,13
 				{
-					// Collect watts and invite others
-					commandIndex = 58;
+					// Collect watts and invite others					
+					if (m_sequence == 3)
+					{
+						// this is the first time we are entering the den, don't collect watts
+						commandIndex = 62;
+					}
+					else
+					{
+						commandIndex = 58;
+					}					
 					m_endIndex = 67;
 				}
 				else if (m_sequence % 5 == 4)	// 4,9,14

--- a/bots/Auto3DaySkipper/Commands.h
+++ b/bots/Auto3DaySkipper/Commands.h
@@ -86,6 +86,8 @@ static const Command m_command[] PROGMEM = {
 	{NOTHING, 1},
 	{A, 30},		// You gained 2,000W!
 	{NOTHING, 1},
+	{A, 30},		// Extra A press if uncatchable
+	{NOTHING, 1},
 	{A, 120},		// WAITING on local communication
 	{NOTHING, 1},
 


### PR DESCRIPTION
I'm leveraging the fact that there is a bit of a window while the game is connecting to others that allows for some extra A presses. This was actually already utilized for entering the raid even if the watts have already been collected.

I had to tweak entering the den the first time, though. The timing was such that now there were too many A presses if the watts had already been collected. Given that in the instructions it says to collect the watts and then save, I added some logic to skip collecting the watts on the first den.